### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: kubdev

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,23 @@
+name: Bug report
+description: Create a bug report to help us address errors in the repository
+title: "[BUG]"
+labels: [bug]
+body:
+  - type: textarea
+    id: bugdescription
+    attributes:
+      label: Description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Please add screenshots (if applicable)
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Add any other context about the problem here
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest features, propose improvements, discuss new ideas.
+title: "[FEATURE]"
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: Provide a general summary of the issue in the Title above
+  - type: textarea
+    id: description
+    attributes:
+      label: Detailed description
+      description: Provide a detailed description of the change or addition you are proposing
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Why is this change important to you? How would you use it?
+        How can it benefit other users?
+    validations:
+      required: true
+  - type: textarea
+    id: possibleimpl
+    attributes:
+      label: Possible implementation
+      description: Not obligatory, but suggest an idea for implementing addition or change
+    validations:
+      required: false
+  - type: textarea
+    id: extrainformation
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this feature?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,29 @@
+name: Other
+description: Use this for any other issues. PLEASE do not create blank issues
+title: "[OTHER]"
+labels: ["awaiting triage"]
+body:
+  - type: markdown
+    attributes:
+      value: "# Other issue"
+  - type: textarea
+    id: issuedescription
+    attributes:
+      label: What would you like to share?
+      description: Provide a clear and concise explanation of your issue.
+    validations:
+      required: true
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this issue?
+    validations:
+      required: false
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - label: Yes, I want to work on this issue!
+          required: false


### PR DESCRIPTION
Things added/changed:

- Add issue templates.
- Add a funding file.
  - Taken and slightly modified from [**WebXDAO**](https://github.com/WebXDAO) repositories.
  - Closes #3.
